### PR TITLE
Azh patch

### DIFF
--- a/src/algos/perturbation.jl
+++ b/src/algos/perturbation.jl
@@ -108,12 +108,12 @@ function perturbate(model::AbstractNumericModel, eigtol::Float64=1.0+1e-6)
     # Q = g_e
     # A = g_s + g_x*C
     # B = g_e
-    C_exo = C[:,1:length(_m)]
-    C_endo = C[:,(length(_m)+1):end]
 
     if size(R,1)>0
+        C_exo = C[:,1:length(_m)]
+        C_endo = C[:,(length(_m)+1):end]
         BiTaylorExpansion(_m, _s, x, C_exo, C_endo)
     else
-        BiTaylorExpansion(zeros(0), _s, x, C_exo, C_endo)
+        BiTaylorExpansion(_m, _s, x, zeros(nx, length(_m)), C)
     end
 end

--- a/test/test_algos.jl
+++ b/test/test_algos.jl
@@ -4,37 +4,12 @@ Pkg.build("QuantEcon")
 import Dolo
 
 
-<<<<<<< HEAD
-filename = joinpath(path,"examples","models","rbc_dtcc_iid_ar1.yaml")
-# filename = joinpath(path,"examples","models","sudden_stop.yaml")
-model_mc = Dolo.yaml_import(filename)
-=======
 fn = joinpath(path,"examples","models","rbc_dtcc_mc.yaml")
 model_mc = Dolo.yaml_import(fn)
->>>>>>> origin/master
 
 drc = Dolo.ConstantDecisionRule(model_mc.calibration[:controls])
 @time dr0, drv0 = Dolo.solve_policy(model_mc, drc) #, verbose=true, maxit=10000 )
 @time dr = Dolo.time_iteration(model_mc, verbose=true, maxit=10000)
-<<<<<<< HEAD
-@time drv = Dolo.evaluate_policy(model_mc, dr, verbose=true, maxit=10000)
-
-@time drd = Dolo.time_iteration_direct(model_mc, dr, verbose=true, maxit=500)
-
-# compare with prerecorded values
-kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
-nvec = [Dolo.evaluate(dr,1,[k])[1] for k in kvec]
-ivec = [Dolo.evaluate(dr,1,[k])[2] for k in kvec]
-# compare  time_iteration_direct
-nvec_d = [Dolo.evaluate(drd,1,[k])[1] for k in kvec]
-ivec_d = [Dolo.evaluate(drd,1,[k])[2] for k in kvec]
-@assert maximum(abs(nvec_d-nvec))<1e-
-
-# compare  vfi
-nvec_0 = [Dolo.evaluate(dr0,1,[k])[1] for k in kvec]
-ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
-@assert maximum(abs(nvec_0-nvec))<1e-4
-=======
 @time drv = Dolo.evaluate_policy(model_mc, dr) #, verbose=true, maxit=10000)
 @time drd = Dolo.time_iteration_direct(model_mc, dr) #, maxit=500)
 #
@@ -51,8 +26,6 @@ ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
 # nvec_0 = [dr0(1,[k])[1] for k in kvec]
 # ivec_0 = [dr0(1,[k])[2] for k in kvec]
 # @assert maxabs(nvec_0-nvec)<1e-4
->>>>>>> origin/master
-
 
 # let's redo when model is stable !
 # ivec_test = [0.295977,  0.257538,  0.21566,  0.173564,  0.132103,  0.0915598,  0.0520067,  0.0134661,  7.01983e-6, 3.40994e-17]
@@ -60,59 +33,32 @@ ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
 # @assert maximum(abs(ivec-ivec_test))<1e-5
 # @assert maximum(abs(nvec-nvec_test))<1e-5
 
-<<<<<<< HEAD
 
-# this one needs a lower value of beta or a better initial guess
-filename = joinpath(path,"examples","models","rbc_dtcc_iid.yaml")
-model = Dolo.yaml_import(filename)
-=======
 import Dolo
 path = Pkg.dir("Dolo")
 fn = joinpath(path,"examples","models","rbc_dtcc_iid.yaml")
 model = Dolo.yaml_import(fn)
->>>>>>> origin/master
 
 @time dr = Dolo.perturbate(model)
 drc = Dolo.ConstantDecisionRule(model.calibration[:controls])
-<<<<<<< HEAD
-@time dr0, drv0 = Dolo.solve_policy(model, drc, verbose=true, maxit=1000 )
-
-
-@time dr = Dolo.time_iteration(model, maxit=1000, verbose=true)
-@time drd = Dolo.time_iteration_direct(model, maxit=1000, verbose=true)
-# @time dr = Dolo.time_iteration_direct(model, dr, maxit=500, verbose=true)
-@time drv = Dolo.evaluate_policy(model, dr, verbose=true)
-
-kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
-nvec = [Dolo.evaluate(dr,1,[k])[1] for k in kvec]
-ivec = [Dolo.evaluate(dr,1,[k])[2] for k in kvec]
-nvec_d = [Dolo.evaluate(drd,1,[k])[1] for k in kvec]
-ivec_d = [Dolo.evaluate(drd,1,[k])[2] for k in kvec]
-nvec_0 = [Dolo.evaluate(dr0,1,[k])[1] for k in kvec]
-ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
-
-@assert maximum(abs(nvec_d-nvec))<1e-5
-@assert maximum(abs(nvec_0-nvec))<1e-5 # not satisfied right now (see tol. of optimizer)
-
-=======
 @time dr = Dolo.time_iteration(model, maxit=100, verbose=true)
->>>>>>> origin/master
 
 @time dr0, drv0 = Dolo.solve_policy(model, drc) #;, verbose=true, maxit=1000 )
 
 @time drd = Dolo.time_iteration_direct(model) #, maxit=1000, verbose=true)
 @time dr = Dolo.time_iteration_direct(model, drd) #, maxit=500, verbose=true)
 
-<<<<<<< HEAD
-# does not work yet
-filename = joinpath(path,"examples","models","rbc_dtcc_ar1.yaml")
-model = Dolo.yaml_import(filename)
-
-Dolo.discretize(model.exogenous)
-
-=======
 @time drv = Dolo.evaluate_policy(model, dr, verbose=true)
 #
+Dolo.simulation(model, dr)
+
+s0 = model.calibration[:states]+0.1
+sim = Dolo.simulation(model, dr, s0; stochastic=true)
+
+figure()
+plot(sim[1,1,:])
+show()
+
 # kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
 # nvec = [dr(1,[k])[1] for k in kvec]
 # ivec = [dr(1,[k])[2] for k in kvec]
@@ -133,9 +79,17 @@ dp = Dolo.discretize(model.exogenous)
 @time dr = Dolo.perturbate(model)
 cdr =Dolo.CachedDecisionRule(dr,dp)
 @time dr = Dolo.time_iteration(model, model.exogenous, cdr)
->>>>>>> origin/master
 @time dr = Dolo.time_iteration(model)
 @time dr0, drv0 = Dolo.solve_policy(model, cdr, verbose=true) #, maxit=10000 )
 @time drv = Dolo.evaluate_policy(model, dr, verbose=true, maxit=10000)
 @time drd = Dolo.time_iteration_direct(model, dr) #, verbose=true) #, maxit=500)
 #
+Dolo.simulation(model, dr)
+
+
+s0 = model.calibration[:states]
+sim = Dolo.simulation(model, dr, s0; stochastic=false)
+size(sim)
+figure()
+plot(sim[1,1,:])
+show()

--- a/test/test_algos.jl
+++ b/test/test_algos.jl
@@ -50,14 +50,16 @@ drc = Dolo.ConstantDecisionRule(model.calibration[:controls])
 
 @time drv = Dolo.evaluate_policy(model, dr, verbose=true)
 #
-Dolo.simulation(model, dr)
+Dolo.simulate(model, dr)
 
 s0 = model.calibration[:states]+0.1
-sim = Dolo.simulation(model, dr, s0; stochastic=true)
+sim = Dolo.simulate(model, dr, s0; stochastic=true)
+Dolo.simulate(model, dr, n_exp=10)
 
-figure()
-plot(sim[1,1,:])
-show()
+# this doesn't work here
+irf = Dolo.response(model, dr, [0.1])
+irf[:k]
+
 
 # kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
 # nvec = [dr(1,[k])[1] for k in kvec]
@@ -84,12 +86,7 @@ cdr =Dolo.CachedDecisionRule(dr,dp)
 @time drv = Dolo.evaluate_policy(model, dr, verbose=true, maxit=10000)
 @time drd = Dolo.time_iteration_direct(model, dr) #, verbose=true) #, maxit=500)
 #
-Dolo.simulation(model, dr)
 
-
-s0 = model.calibration[:states]
-sim = Dolo.simulation(model, dr, s0; stochastic=false)
-size(sim)
-figure()
-plot(sim[1,1,:])
-show()
+Dolo.simulate(model, dr, n_exp=10)
+sim = Dolo.response(model, dr, [0.01])
+sim

--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -6,15 +6,23 @@ import Distributions
 mu = [0.0, 0.0]
 Sigma = [1.0 0.0; 0.0 2.0]
 d = Dolo.MvNormal(mu, Sigma)
-sim = Dolo.simulate(d, 5, 200)
+sim = Dolo.simulate(d, 1, 200, [0.1, -0.01])
+sim = Dolo.simulate(d, 1, 200, [0.1, -0.01]; stochastic=false)
 dp = Dolo.discretize(d)
 
 
 # test VAR
 var = Dolo.VAR1([0.0,0.0],[0.99 0.0; 0.0 0.08],eye(2)*0.01)
+
+
 sim = Dolo.simulate(var, 5, 200)
+sim = Dolo.simulate(var, 5, 200, [0.8, 0.8])
+sim = Dolo.simulate(var, 1, 200, [0.8, 0.8]; stochastic=false)
+
 dp = Dolo.discretize(var)
 
+
+import PyPlot
 
 
 


### PR DESCRIPTION
@AnasZa , please have a look at the changes and then marge them.

I unified the iid and var case in the simulate routine(model).

response(model) for irfs is not perfect. It doesn't do anything for iid shocks. Maybe we need to define for any process p: `simulate(p, e0, shock)` which would start the process with values e0 in date t=0, and set innovation equal to shock in date 1. This would unify everything.